### PR TITLE
ci: Update build base to Ubuntu 20.04

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,0 @@
-export CARGO_TARGET_DIR=/dev/shm

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,23 +56,14 @@ jobs:
       fail-fast: false
       matrix:
         job:
-          - { target: x86_64-unknown-linux-gnu, os: ubuntu-latest, container: quay.io/pypa/manylinux2014_x86_64 }
+          # use ubuntu 20.04 to keep minimum glibc version to 2.31
+          - { target: x86_64-unknown-linux-gnu, os: ubuntu-20.04 }
     name: ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
-    # Use a container with GLIBC 2.17, make build compatible until that version
-    container: ${{ matrix.job.container }}
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install dependencies
-        shell: bash
-        run: |
-          case ${{ matrix.job.target }} in
-            x86_64-unknown-linux-gnu) yum install -y alsa-lib-devel;;
-          esac
+      - uses: actions/checkout@v4
 
       - uses: Swatinem/rust-cache@v2
-        if: ${{ matrix.job.container == null }}
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -107,17 +98,13 @@ jobs:
       - name: Get Changelog Entry
         if: startsWith(github.ref, 'refs/tags/')
         id: changelog_reader
-        # fix 2.2.2 to avoid update to node 20 because compatibility issues with
-        # container `quay.io/pypa/manylinux2014_x86_64`
-        uses: mindsers/changelog-reader-action@v2.2.2
+        uses: mindsers/changelog-reader-action@v2.2.3
         with:
           version: v${{ env.PROJECT_VERSION }}
           path: ./CHANGELOG.md
 
       - name: Publish
-        # fix v1 to avoid update to node 20 because compatibility issues with
-        # container `quay.io/pypa/manylinux2014_x86_64`
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           body: ${{ steps.changelog_reader.outputs.changes }}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ vendor
 vendor.tar.gz
 *.tar.gz
 PKGBUILD
+.envrc


### PR DESCRIPTION
This increases the GLIB min version dependency to 2.31