### PR TITLE
fix: prevent cpu spinning on event stream reconnection

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ use flexi_logger::DeferredNow;
 use flexi_logger::TS_DASHES_BLANK_COLONS_DOT_BLANK;
 use log::Record;
 use tokio::sync::mpsc;
+use tokio::time::Duration;
 
 mod backend;
 
@@ -107,17 +108,22 @@ pub async fn main() -> Result<()> {
         .format_for_stderr(ts_log_format)
         .use_utc()
         .start()?;
-    const INITIAL_BACKOFF_SECS: f64 = 0.2;
-    const MAX_BACKOFF_SECS: f64 = 5.0;
-    let mut backoff = INITIAL_BACKOFF_SECS;
+    const INITIAL_BACKOFF: Duration = Duration::from_millis(200);
+    const MAX_BACKOFF: Duration = Duration::from_secs(5);
+    const RESTART_DELAY: Duration = Duration::from_millis(500);
+    let mut backoff = INITIAL_BACKOFF;
 
     loop {
         match run().await {
-            Ok(_) => backoff = INITIAL_BACKOFF_SECS,
+            Ok(_) => {
+                log::warn!("event stream ended, reconnecting in {RESTART_DELAY:?}");
+                tokio::time::sleep(RESTART_DELAY).await;
+                backoff = INITIAL_BACKOFF;
+            }
             Err(e) => {
-                log::error!("{e}. Retrying in {backoff:.1}s");
-                std::thread::sleep(std::time::Duration::from_secs_f64(backoff));
-                backoff = (backoff * 2.0).min(MAX_BACKOFF_SECS);
+                log::error!("{e}. Retrying in {backoff:?}");
+                tokio::time::sleep(backoff).await;
+                backoff = (backoff * 2).min(MAX_BACKOFF);
             }
         }
     }


### PR DESCRIPTION
## Problem

i3-auto-layout was consuming high CPU due to two issues in the main reconnection loop:

1. **Tight reconnection loop** — When the event stream ended cleanly (`Ok(())`), `run()` was called again immediately with zero delay. If the IPC stream ended prematurely, this created a CPU-burning spin loop.
2. **Blocking sleep in async context** — `std::thread::sleep` blocked the entire Tokio runtime thread during error backoff, preventing graceful shutdown and wasting resources.

## Fix

- Added a 500ms delay (`RESTART_DELAY`) on the `Ok` path to prevent tight reconnection loops
- Replaced `std::thread::sleep` with `tokio::time::sleep` to yield to the async runtime
- Added a warning log when the event stream ends unexpectedly
- Switched backoff constants from `f64` seconds to `Duration` for type safety