### PR TITLE
release: Version 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v0.4.5](https://github.com/pando85/i3-auto-layout/tree/v0.4.5) - 2026-08-14
+
+### Fixed
+
+- Update swayipc-async to 3.0.0 for swayipc-types v2 compatibility ([17db3f0](https://github.com/pando85/i3-auto-layout/commit/17db3f0d580565aacea3629df7f5f3c646996bed))
+- Use specific version v6.0.2 for rs-clippy-check action ([85322ec](https://github.com/pando85/i3-auto-layout/commit/85322eca6221004f9ced044352ead40529edeb76))
+- Prevent cpu spinning on event stream reconnection ([18d8646](https://github.com/pando85/i3-auto-layout/commit/18d864687e998c3d6ff90ff37040cdc6eeea6dd0))
+
+### Build
+
+- Update pre-commit hook renovatebot/pre-commit-hooks to v41.173.1 ([9daf607](https://github.com/pando85/i3-auto-layout/commit/9daf607724c17a86a6e55473db6db3d037c160f6))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v42 ([7232eea](https://github.com/pando85/i3-auto-layout/commit/7232eeaeade6455345db4257bec9c8d5998136da))
+- Update Rust crate tokio to v1.49.0 ([eaca6d4](https://github.com/pando85/i3-auto-layout/commit/eaca6d4a02d180c58540b3147fd08398dffe3dda))
+- Update Rust crate tokio-stream to v0.1.18 ([38b95d5](https://github.com/pando85/i3-auto-layout/commit/38b95d5947c2d420a4b116c28aff098e045d0f1a))
+- Update pre-commit hook adrienverge/yamllint to v1.38.0 ([ba1e7fd](https://github.com/pando85/i3-auto-layout/commit/ba1e7fdad449dcdc4ead6386cf9add8bea61aad2))
+- Update pre-commit hook alessandrojcm/commitlint-pre-commit-hook to v9.24.0 ([40abc0c](https://github.com/pando85/i3-auto-layout/commit/40abc0c38681a2261de9dea4fb29788e99c2e8a3))
+- Update Rust crate flexi_logger to v0.31.8 ([4a2b9d8](https://github.com/pando85/i3-auto-layout/commit/4a2b9d8e38d51dd0f41813b6c04e13195101081c))
+- Update Rust crate anyhow to v1.0.101 ([f5bb2c9](https://github.com/pando85/i3-auto-layout/commit/f5bb2c93df9449272c5d2cf94d28b4ee91b7d736))
+- Update Rust crate anyhow to v1.0.102 ([e99c769](https://github.com/pando85/i3-auto-layout/commit/e99c769a01451d447dd80526d6d0ce206dedaf07))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v42.95.1 ([75074a1](https://github.com/pando85/i3-auto-layout/commit/75074a1c005edba3bd37aa4bcf29d4d84acdfacd))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v43 ([f5477fd](https://github.com/pando85/i3-auto-layout/commit/f5477fd70f7450d49f8bbe89e575b6c51038b07f))
+- Update Rust crate swayipc-types to v2 ([acbc1cc](https://github.com/pando85/i3-auto-layout/commit/acbc1ccb7957483ff8fc307178597b386c60d016))
+- Update Rust crate tokio to v1.50.0 ([62d70d5](https://github.com/pando85/i3-auto-layout/commit/62d70d50a28e55599d93c012e1e0c952340e7873))
+- Update Rust crate futures to v0.3.32 ([1979e70](https://github.com/pando85/i3-auto-layout/commit/1979e70b71c542b4d9c5ba28c8fc19f949ed63e6))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v43.102.2 ([9d0a397](https://github.com/pando85/i3-auto-layout/commit/9d0a397f6cc5eae676f3f514077b47e206fea0d2))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v43.102.3 ([9ef0bcc](https://github.com/pando85/i3-auto-layout/commit/9ef0bcc8ab41fea53a4a1fa0ad572b2706c8c08a))
+- Update KSXGitHub/github-actions-deploy-aur action to v4.1.2 ([30e7259](https://github.com/pando85/i3-auto-layout/commit/30e7259d867189342ec58b1fc184c6ff84e8963a))
+- Update KSXGitHub/github-actions-deploy-aur action to v4.1.3 ([952cddd](https://github.com/pando85/i3-auto-layout/commit/952cdddf60305f9ea338812e3b04653764bc686b))
+- Update Rust crate tokio to v1.52.1 ([1c4c306](https://github.com/pando85/i3-auto-layout/commit/1c4c306ee8c06f45212682d63058203c66051d65))
+- Update softprops/action-gh-release action to v3 ([77aaffb](https://github.com/pando85/i3-auto-layout/commit/77aaffb588ef460137649f086cb5e078e5d646e2))
+- Update clechasseur/rs-clippy-check action to v6 ([39906d8](https://github.com/pando85/i3-auto-layout/commit/39906d8b792eb52ec20c29c1b2195140cf446dc7))
+- Update clechasseur/rs-clippy-check action to v6.0.3 ([75900b1](https://github.com/pando85/i3-auto-layout/commit/75900b10e3d5482c71500258c9a05840102cec76))
+- Update pre-commit hook alessandrojcm/commitlint-pre-commit-hook to v9.25.0 ([4cd3fe4](https://github.com/pando85/i3-auto-layout/commit/4cd3fe416e388828fe7243468bc9d4bde0f3e8a7))
+- Update Rust crate tokio to v1.52.2 ([a580ce8](https://github.com/pando85/i3-auto-layout/commit/a580ce83bf282e524b642da88eae84fa5de1df29))
+- Update Rust crate tokio to v1.52.3 ([075998e](https://github.com/pando85/i3-auto-layout/commit/075998ee3790175e154c4880dde46c7e6fb9005c))
+- Update clechasseur/rs-clippy-check action to v6.0.4 ([5ffeb72](https://github.com/pando85/i3-auto-layout/commit/5ffeb72f31edb9fc7f220916a4ba0ec6b1bf8a40))
+- Update mindsers/changelog-reader-action action to v2.4.0 ([d3c05f7](https://github.com/pando85/i3-auto-layout/commit/d3c05f706d0ff9d9f562de6d90683a0d172b80cf))
+- Update Rust crate flexi_logger to v0.31.9 ([767b427](https://github.com/pando85/i3-auto-layout/commit/767b427ea008eb4237e2cf375437c14af85031d3))
+- Update Rust crate log to v0.4.30 ([5bb0a19](https://github.com/pando85/i3-auto-layout/commit/5bb0a19d67158c29e92cb986109b11c5194bbb8e))
+- Update clechasseur/rs-clippy-check action to v6.0.5 ([65ded2c](https://github.com/pando85/i3-auto-layout/commit/65ded2c2a391ea89a302d4dba599b827418cc167))
+- Update Rust crate anyhow to v1.0.103 ([bea5298](https://github.com/pando85/i3-auto-layout/commit/bea5298af6339b1b90c9a12fc4c2aebe9b38f552))
+- Update Rust crate log to v0.4.33 ([ae80276](https://github.com/pando85/i3-auto-layout/commit/ae802762952b71cbe9bf1c3a1a48a3a6db49f27e))
+- Update actions/checkout action to v7 ([80471df](https://github.com/pando85/i3-auto-layout/commit/80471df3c3d1665bea5c131e16a1072ec562576f))
+- Update actions/cache action to v6 ([f76ab3f](https://github.com/pando85/i3-auto-layout/commit/f76ab3f4a3036cab0db7454cce956fdcacf80c71))
+- Update pre-commit hook alessandrojcm/commitlint-pre-commit-hook to v9.26.0 ([692b9a0](https://github.com/pando85/i3-auto-layout/commit/692b9a017f95356be2ee8857fa431618824fd979))
+- Update Rust crate tokio to v1.52.4 ([5b3db28](https://github.com/pando85/i3-auto-layout/commit/5b3db28c22480a6b9f6d6cf37c49a2bac77ae46c))
+- Update Rust crate anyhow to v1.0.104 ([4394666](https://github.com/pando85/i3-auto-layout/commit/43946662340d4e6ce8ffeec07f82ab028e7142f9))
+- Update clechasseur/rs-clippy-check action to v6.0.6 ([4c08fe8](https://github.com/pando85/i3-auto-layout/commit/4c08fe8c13365f537067339f8dba7c2ec5540d82))
+- Update pre-commit hook renovatebot/pre-commit-hooks to v43.288.0 ([9c48b39](https://github.com/pando85/i3-auto-layout/commit/9c48b3982bb96270be197cc8dd890a410f10b0f5))
+- Update clechasseur/rs-clippy-check action to v6.0.7 ([4860473](https://github.com/pando85/i3-auto-layout/commit/48604738d922989ab04f0c3aa8fadc871dd0aa3b))
+
+### Refactor
+
+- Improve code maintainability and fix edition ([79bd1bc](https://github.com/pando85/i3-auto-layout/commit/79bd1bc476b9f59f5705cb36eb4fa1c78170843d))
+
+### Chore
+
+- Add opencode release skill and improve release script ([139943b](https://github.com/pando85/i3-auto-layout/commit/139943ba344eb4458a78c772161007882368e1f0))
+
+### Revert
+
+- Restore edition 2024 and if-let chains ([0d1d3f7](https://github.com/pando85/i3-auto-layout/commit/0d1d3f78cb1151004304cd246334b16e44e8f445))
+
 ## [v0.4.4](https://github.com/pando85/i3-auto-layout/tree/v0.4.4) - 2025-12-25
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,7 +303,7 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "i3-auto-layout"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "i3-auto-layout"
 description = "Automatic, optimal tiling for i3wm"
-version = "0.4.4"
+version = "0.4.5"
 authors = ["Pando85 <pando855@gmail.com>"]
 edition = "2024"
 homepage = "https://github.com/pando85/i3-auto-layout"


### PR DESCRIPTION
## Release v0.4.5

Patch release with bug fixes and dependency updates.

### Fixed
- Prevent CPU spinning on event stream reconnection
- Update swayipc-async to 3.0.0 for swayipc-types v2 compatibility
- Use specific version v6.0.2 for rs-clippy-check action

### Build
- Multiple dependency updates (tokio, anyhow, flexi_logger, etc.)
- Pre-commit hook and GitHub Actions updates